### PR TITLE
Ajuste na função show para mostrar o nome do arquivo ao salvar.

### DIFF
--- a/canvas.php
+++ b/canvas.php
@@ -494,12 +494,14 @@ class canvas{
     }
   }
   
-  function show(){
+  function show($filename = NULL){
     if(headers_sent()){
       $this->error = "Headers already sent.";
       return false;    
     }else{
-      header("Content-type: image/{$this->extension}");
+      $filename = $filename ? $filename : "image.{$this->extension}"; 
+	    header("Content-type: image/{$this->extension}");
+	    header("Content-Disposition:; filename={$filename}");	
       $this->output_image();
       imagedestroy($this->image);
       exit;


### PR DESCRIPTION
Ajuste na função show para mostrar o nome do arquivo ao clicar em "salvar como".

Linhas:
- 497 (Adicionado parâmetro "filename").
- 502 (Verifica se o parâmetro foi informado ou insere um nome amigável padrão).
- 504 (Insere o header para nomear o download).
